### PR TITLE
Display include folder as separate part of project in Visual Studio's Solution Explorer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ endif ()
 
 add_subdirectory(external)
 add_subdirectory(src)
+add_subdirectory(include)
 
 ## We need to setup the RocksDB build environment to match our system
 include_directories(${CMAKE_SOURCE_DIR}/external/zstd/lib)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,6 @@
+# list include header files in Visual Studio Solution Explorer
+
+file(GLOB_RECURSE IncludeHeaders "${CMAKE_SOURCE_DIR}/include/*.h*")
+add_library(Include ${IncludeHeaders})
+set_target_properties(Include PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(Include PRIVATE "${CMAKE_SOURCE_DIR}/include")


### PR DESCRIPTION
Those files are hard to find because Visual Studio 2015 displays the public header files in the "External References" directory among a lot of system headers.

This problem is not new, found a solution here: 
https://stackoverflow.com/questions/32584319/display-include-directory-as-separate-part-of-project-in-visual-studio-using-cma