### PR TITLE
RPC: add current max block cumulative size to /getinfo

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -278,6 +278,7 @@ struct COMMAND_RPC_GET_INFO {
     std::string top_block_hash;
     uint64_t difficulty;
     uint64_t cumulative_difficulty;
+    uint64_t max_cumulative_block_size;
     uint64_t next_reward;
     uint64_t min_fee;
     uint64_t transactions_count;
@@ -303,6 +304,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(top_block_hash)
       KV_MEMBER(difficulty)
       KV_MEMBER(cumulative_difficulty)
+      KV_MEMBER(max_cumulative_block_size)
       KV_MEMBER(next_reward)
       KV_MEMBER(min_fee)
       KV_MEMBER(transactions_count)

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1130,6 +1130,7 @@ bool RpcServer::onGetInfo(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_
   res.height = topIndex + 1;
   res.difficulty = m_core.getDifficultyForNextBlock();
   res.cumulative_difficulty = m_core.getBlockCumulativeDifficulty(topIndex);
+  res.max_cumulative_block_size = (uint64_t)m_core.getCurrency().maxBlockCumulativeSize(res.height);
   Crypto::Hash last_block_hash = m_core.getTopBlockHash();
   res.top_block_hash = Common::podToHex(last_block_hash);
   res.block_major_version = m_core.getBlockMajorVersionForHeight(m_core.getTopBlockIndex());


### PR DESCRIPTION
Just because it is in karbo1