### PR TITLE
Add  get_last_transfers wallet RPC method

### DIFF
--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -69,6 +69,7 @@ private:
   bool on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STOP::response& res);
   bool on_get_payments(const wallet_rpc::COMMAND_RPC_GET_PAYMENTS::request& req, wallet_rpc::COMMAND_RPC_GET_PAYMENTS::response& res);
   bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res);
+  bool on_get_last_transfers(const wallet_rpc::COMMAND_RPC_GET_LAST_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_LAST_TRANSFERS::response& res);
   bool on_get_transaction(const wallet_rpc::COMMAND_RPC_GET_TRANSACTION::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSACTION::response& res);
   bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);
   bool on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res);

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -200,6 +200,28 @@ using CryptoNote::ISerializer;
 		};
 	};
 
+  struct COMMAND_RPC_GET_LAST_TRANSFERS
+  {
+    struct request
+    {
+      size_t count = 1000;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(count)
+      }
+    };
+    struct response
+    {
+      std::list<Transfer> transfers;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(transfers)
+      }
+    };
+  };
+
 	/* Command: get_transaction */
 	struct COMMAND_RPC_GET_TRANSACTION
 	{


### PR DESCRIPTION
Add `get_last_transfers` RPC  method for `simplewallet` because `get_transfers` may be overkill for wallets with a lots of transactions.

There is a `count` param to specify how many last transactions to fetch.

Input:
```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "get_last_transfers",
  "params": {
   "count":100
  }
}
```

Output is the same as in `get_transfers` method.