### PR TITLE
Rename getbalance to get_balance for consistency

### DIFF
--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -194,7 +194,7 @@ namespace Tools {
 
       static const std::unordered_map<std::string, JsonMemberMethod> s_methods =
       {
-        { "getbalance"         , makeMemberMethod(&wallet_rpc_server::on_getbalance)        },
+        { "get_balance"        , makeMemberMethod(&wallet_rpc_server::on_get_balance)       },
         { "transfer"           , makeMemberMethod(&wallet_rpc_server::on_transfer)          },
         { "store"              , makeMemberMethod(&wallet_rpc_server::on_store)             },
         { "stop_wallet"        , makeMemberMethod(&wallet_rpc_server::on_stop_wallet)       },
@@ -237,7 +237,7 @@ namespace Tools {
 
   //------------------------------------------------------------------------------------------------------------------------------
 
-  bool wallet_rpc_server::on_getbalance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req,
+  bool wallet_rpc_server::on_get_balance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req,
     wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res)
   {
     res.locked_amount = m_wallet.pendingBalance();

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -63,7 +63,7 @@ private:
   virtual void processRequest(const CryptoNote::HttpRequest& request, CryptoNote::HttpResponse& response) override;
 
 	//json_rpc
-  bool on_getbalance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res);
+  bool on_get_balance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res);
   bool on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_TRANSFER::response& res);
   bool on_store(const wallet_rpc::COMMAND_RPC_STORE::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res);
   bool on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::request& req, wallet_rpc::COMMAND_RPC_STOP::response& res);


### PR DESCRIPTION
because all other methods have under_score 