### PR TITLE
Improve coinbase output validation

### DIFF
--- a/src/CryptoNoteCore/TransactionValidationErrors.h
+++ b/src/CryptoNoteCore/TransactionValidationErrors.h
@@ -57,7 +57,8 @@ enum class TransactionValidationError {
   OUTPUT_INVALID_DECOMPOSED_AMOUNT,
   INVALID_FEE,
   SIZE_TOO_LARGE,
-  OUTPUTS_INVALID_COUNT
+  OUTPUTS_INVALID_COUNT,
+  BASE_TRANSACTION_OUTPUT_WRONG_TYPE
 };
 
 // custom category:
@@ -110,6 +111,7 @@ public:
       case TransactionValidationError::INVALID_FEE: return "Fee is too small and it's not a fusion transaction";
       case TransactionValidationError::SIZE_TOO_LARGE: return "Transaction is too large (in bytes)";
       case TransactionValidationError::OUTPUTS_INVALID_COUNT: return "Only 1 output in coinbase transaction allowed";
+      case TransactionValidationError::BASE_TRANSACTION_OUTPUT_WRONG_TYPE: return "Coinbase transaction output must be OutputKey type";
       default: return "Unknown error";
     }
   }


### PR DESCRIPTION
  - Add validation for coinbase output type.
  - Merge major block 5 validation into single block.
  
In order to validate miner signature corresponds to the output address we must be sure that the output type used is not multi-signature other way there will be runtime error at:
```
    Crypto::PublicKey ephPubKey = boost::get<KeyOutput>(blockTemplate.baseTransaction.outputs[0].target).key;
```